### PR TITLE
feat: upgrade infracost to latest version (v0.6.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:3.12
 
 # GitHub actions don't support build-args (https://github.community/t/feature-request-build-args-support-in-docker-container-actions/16846/4)
 # so using ENV might help people who need to fork/change it
-ENV TERRAFORM_VERSION=0.13.3 \
-  TERRAFORM_BINARY=terraform \
-  INFRACOST_VERSION=latest
+ENV TERRAFORM_VERSION=0.13.4 \
+  INFRACOST_VERSION=latest \
+  INFRACOST_SKIP_UPDATE_CHECK=true
 
 RUN apk --update --no-cache add ca-certificates openssl sudo curl git jq && \
   wget -O terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
@@ -12,7 +12,7 @@ RUN apk --update --no-cache add ca-certificates openssl sudo curl git jq && \
   rm -rf terraform.zip /var/cache/apk/*
 
 RUN curl --silent --location https://github.com/infracost/infracost/releases/${INFRACOST_VERSION}/download/infracost-linux-amd64.tar.gz | tar xz -C /tmp
-RUN mv /tmp/infracost-linux-amd64 /usr/local/bin/infracost
+RUN mv /tmp/infracost-linux-amd64 /bin/infracost
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,44 @@
 # Infracost GitHub action
 
-This action runs [Infracost](https://infracost.io) on the provided terraform directory in the master branch and the pull request whenever a `.tf` file changes. It automatically adds a pull request comment showing the cost estimate `diff` if a percentage threshold is crossed.
+This action runs [Infracost](https://infracost.io) against the master branch and the pull request whenever a Terraform file changes. It automatically adds a pull request comment showing the cost estimate difference (similar to `git diff`) if a percentage threshold is crossed.
 
 <img src="screenshot.png" width=557 alt="Example screenshot" />
 
 ## Inputs
 
-### `terraform_dir`
+### `tfjson`
 
-**Required** Path of the repo's terraform directory.
+**Optional** Path to Terraform plan JSON file.
+
+### `tfplan`
+
+**Optional** Path to Terraform plan file relative to 'tfdir'. Requires 'tfdir' to be set.
+
+### `tfdir`
+
+**Optional** Path to the Terraform code directory (default is current working directory).
+
+### `tfflags`
+
+**Optional** Flags to pass to the 'terraform plan' command.
 
 ### `percentage_threshold`
 
 **Optional** The absolute percentage threshold that triggers a pull request comment with the diff. Defaults to 0, meaning that a comment is posted if the cost estimate changes. For example, set to 5 to post a comment if the cost estimate changes by plus or minus 5%.
 
+### `pricing_api_endpoint`
+
+**Optional** Specify an alternate price list API URL (default is https://pricing.api.infracost.io).
+
 ## Environment variables
 
 The AWS secrets mentioned below are used by terraform init and plan commands. As mentioned in the [Infracost FAQ](https://www.infracost.io/docs/faq) you can run `infracost` in your terraform directories without worrying about security or privacy issues as no cloud credentials, secrets, tags or Terraform resource identifiers are sent to Infracost's cloud pricing API. Infracost does not make any changes to your Terraform state or cloud resources.
 
+Standard Terraform env vars can also be added if required, e.g. `TF_CLI_ARGS`.
+
 ### `INFRACOST_API_KEY`
 
-**Required if the Infracost hosted pricing API is used (default behavior)** To get an API key [download Infracost](https://www.infracost.io/docs/#installation) and run `infracost register`.
+**Required** To get an API key [download Infracost](https://www.infracost.io/docs/#installation) and run `infracost register`.
 
 ### `AWS_ACCESS_KEY_ID`
 
@@ -34,8 +52,6 @@ The AWS secrets mentioned below are used by terraform init and plan commands. As
 
 **Required** GitHub token used to post comments, should be set to `${{ secrets.GITHUB_TOKEN }}` to use the default GitHub token available to actions.
 
-Standard Terraform env vars can also be added if required, e.g. `TF_CLI_ARGS`.
-
 ## Outputs
 
 ### `master_monthly_cost`
@@ -48,41 +64,43 @@ The pull request's monthly cost estimate.
 
 ## Usage
 
-1. [Add repo secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository) for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to your GitHub repo. As a security precaution, read-only AWS IAM creds can be used.
+1. [Add repo secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository) for `INFRACOST_API_KEY`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to your GitHub repo.
 
-2. Create a new file in `.github/workflows/infracost.yml` in your repo with the following content. You must set the `terraform_dir` value, everything else should work out of the box.
-```
-on:
-  push:
-    paths:
-    - '**.tf'
-    - '**.tfvars'
-jobs:
-  infracost:
-    runs-on: ubuntu-latest
-    name: Show infracost diff
-    steps:
-    - name: Checkout master branch
-      uses: actions/checkout@v2
-      with:
-        ref: master
-        path: master
-    - name: Checkout pull request branch
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        path: pull_request
-    - name: Run infracost diff
-      uses: infracost/infracost-gh-action@v0.1.2
-      env:
-        INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        ##### You should only need to modify the following #####
-        terraform_dir: PATH/TO/MY/TERRAFORM
-```
+2. Create a new file in `.github/workflows/infracost.yml` in your repo with the following content. Use the Inputs and Environment Variables section above to decide which `env` and `with` options work for your Terraform setup. The following example uses `tfdir` and `tfflags` so it would be the equivalent of running `terraform -var-file=myvars.tfvars` inside the directory with the terraform code.
+
+  ```
+  on:
+    push:
+      paths:
+      - '**.tf'
+      - '**.tfvars'
+      - '**.tfvars.json'    
+  jobs:
+    infracost:
+      runs-on: ubuntu-latest
+      name: Show infracost diff
+      steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          path: master
+      - name: Checkout pull request branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pull_request
+      - name: Run infracost diff
+        uses: infracost/infracost-gh-action@master
+        env:
+          INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tfdir: PATH/TO/CODE
+          tfflags: -var-file=myvars.tfvars
+  ```
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -5,13 +5,25 @@ branding:
   icon: trending-up
   color: yellow
 inputs:
-  terraform_dir:
-    description: Path of the repo's terraform directory.
-    required: true
+  tfjson:
+    description: Path to Terraform plan JSON file.
+    required: false
+  tfplan:
+    description: Path to Terraform plan file relative to 'tfdir'. Requires 'tfdir' to be set.
+    required: false
+  tfdir:
+    description: Path to the Terraform code directory (default is current working directory).
+    required: false
+  tfflags:
+    description: Flags to pass to the 'terraform plan' command.
+    required: false 
   percentage_threshold:
     description: The absolute percentage threshold that triggers a pull request comment with the diff. Defaults to 0, meaning that a comment is posted if the cost estimate changes. For example, set to 5 to post a comment if the cost estimate changes by plus or minus 5%.
     required: false
     default: 0
+  pricing_api_endpoint:
+    description: Specify an alternate price list API URL (default is https://pricing.api.infracost.io).
+    required: false
 outputs:
   master_monthly_cost:
     description: The master branch's monthly cost estimate.
@@ -21,5 +33,9 @@ runs:
   using: docker
   image: Dockerfile
   args:
-    - ${{ inputs.terraform_dir }}
+    - ${{ inputs.tfjson }}
+    - ${{ inputs.tfplan }}
+    - ${{ inputs.tfdir }}
+    - ${{ inputs.tfflags }}
     - ${{ inputs.percentage_threshold }}
+    - ${{ inputs.pricing_api_endpoint }}


### PR DESCRIPTION
Adds support for all arguments that might be useful

The GH action will now fail if infracost command fails, as there is no point in continuing. The debug logs are output so users can tell why it failed.

See https://github.com/infracost/ci-demo/runs/1232620312?check_suite_focus=true#step:5:12 for an example output.