### PR TITLE
refactor: use the newly supported default entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Assuming you have [downloaded Infracost](https://www.infracost.io/docs/#quick-st
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Do not change
           # See the cloud credentials section for the options
         with:
-          entrypoint: /scripts/ci/diff.sh # Do not change
           path: path/to/code
           terraform_plan_flags: -var-file=my.tfvars
   ```
@@ -108,8 +107,7 @@ Assuming you have [downloaded Infracost](https://www.infracost.io/docs/#quick-st
           INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          entrypoint: /scripts/ci/diff.sh # Do not change
-          path: plan.json # Do not change
+          path: plan.json # Do not change as this file is generated above
   ```
 
 3. Send a new pull request to change something in Terraform that costs money; a comment should be posted on the pull request. Check the GitHub Actions logs and [this page](https://www.infracost.io/docs/integrations/cicd#cicd-troubleshooting) if there are issues.

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,7 @@ outputs:
 runs:
   using: docker
   image: docker://infracost/infracost:latest # Use a specific version instead of latest if locking is preferred
+  entrypoint: /scripts/ci/diff.sh # Do not change, this script lives in the Docker image and runs the GitHub Action logic
   args:
     - ${{ inputs.path }}
     - ${{ inputs.terraform_plan_flags }}


### PR DESCRIPTION
This way users don’t have to provide/know about this when using the action
See https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsentrypoint

See https://github.com/infracost/gh-actions-demo/pull/32 for a test/demo